### PR TITLE
Fix: subgraph codegen

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "docs:build": "typedoc",
     "docs:watch": "typedoc --watch",
     "format": "biome format . --write",
-    "generate:graphql": "graphql-codegen && npm run lint",
+    "generate:graphql": "graphql-codegen",
     "install:docusaurus": "cd docs && npm install",
     "lint": "biome check .",
     "lint:fix": "npm run lint -- --apply",
@@ -47,5 +47,26 @@
     "sinon": "^15.2.0",
     "ts-node": "^9.1.1",
     "typescript": "^5.0.2"
+  },
+  "codegen": {
+    "schema": "https://v4.subgraph.goerli.oceanprotocol.com/subgraphs/name/oceanprotocol/ocean-subgraph",
+    "documents": "./src/**/*.gql.ts",
+    "generates": {
+      "./src/@types/subgraph/api.ts": {
+        "plugins": ["typescript"]
+      },
+      "./src/": {
+        "preset": "near-operation-file",
+        "presetConfig": {
+          "baseTypesPath": "@types/subgraph/api.ts",
+          "extension": ".generated.ts"
+        },
+        "plugins": ["typescript-operations"],
+        "config": {
+          "omitOperationSuffix": true,
+          "typesPrefix": "I"
+        }
+      }
+    }
   }
 }

--- a/src/package.json
+++ b/src/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@oceanprotocol/lib": "3.1.1",
-    "@urql/exchange-refocus": "^1.0.0",
     "axios": "^1.3.4",
     "decimal.js": "^10.4.3",
     "ethers": "^5.7.2",
@@ -34,9 +33,7 @@
     "documents": "./src/**/*.gql.ts",
     "generates": {
       "./src/@types/subgraph/api.ts": {
-        "plugins": [
-          "typescript"
-        ]
+        "plugins": ["typescript"]
       },
       "./src/": {
         "preset": "near-operation-file",
@@ -44,9 +41,7 @@
           "baseTypesPath": "@types/subgraph/api.ts",
           "extension": ".generated.ts"
         },
-        "plugins": [
-          "typescript-operations"
-        ],
+        "plugins": ["typescript-operations"],
         "config": {
           "omitOperationSuffix": true,
           "typesPrefix": "I"

--- a/src/utils/subgraph/TokenPriceQuery.gql.generated.ts
+++ b/src/utils/subgraph/TokenPriceQuery.gql.generated.ts
@@ -1,68 +1,9 @@
-import * as Types from '../../@types/subgraph/api'
+import * as Types from '../../@types/subgraph/api';
 
 export type ITokenPriceQueryVariables = Types.Exact<{
-  datatokenId: Types.Scalars['ID']['input']
-  account?: Types.InputMaybe<Types.Scalars['String']['input']>
-}>
+  datatokenId: Types.Scalars['ID']['input'];
+  account?: Types.InputMaybe<Types.Scalars['String']['input']>;
+}>;
 
-export type ITokenPriceQuery = {
-  __typename?: 'Query'
-  token?: {
-    __typename?: 'Token'
-    id: string
-    symbol?: string | null
-    name?: string | null
-    templateId?: number | null
-    publishMarketFeeAddress?: string | null
-    publishMarketFeeToken?: string | null
-    publishMarketFeeAmount?: any | null
-    orders?: Array<{
-      __typename?: 'Order'
-      tx: string
-      serviceIndex: number
-      createdTimestamp: number
-      reuses?: Array<{
-        __typename?: 'OrderReuse'
-        id: string
-        caller: string
-        createdTimestamp: number
-        tx: string
-        block: number
-      }> | null
-    }> | null
-    dispensers?: Array<{
-      __typename?: 'Dispenser'
-      id: string
-      active: boolean
-      isMinter?: boolean | null
-      maxBalance: any
-      token: {
-        __typename?: 'Token'
-        id: string
-        name?: string | null
-        symbol?: string | null
-      }
-    }> | null
-    fixedRateExchanges?: Array<{
-      __typename?: 'FixedRateExchange'
-      id: string
-      exchangeId: string
-      price: any
-      publishMarketSwapFee?: any | null
-      active: boolean
-      baseToken: {
-        __typename?: 'Token'
-        symbol?: string | null
-        name?: string | null
-        address: string
-        decimals: number
-      }
-      datatoken: {
-        __typename?: 'Token'
-        symbol?: string | null
-        name?: string | null
-        address: string
-      }
-    }> | null
-  } | null
-}
+
+export type ITokenPriceQuery = { __typename?: 'Query', token?: { __typename?: 'Token', id: string, symbol?: string | null, name?: string | null, templateId?: number | null, publishMarketFeeAddress?: string | null, publishMarketFeeToken?: string | null, publishMarketFeeAmount?: any | null, orders?: Array<{ __typename?: 'Order', tx: string, serviceIndex: number, createdTimestamp: number, reuses?: Array<{ __typename?: 'OrderReuse', id: string, caller: string, createdTimestamp: number, tx: string, block: number }> | null }> | null, dispensers?: Array<{ __typename?: 'Dispenser', id: string, active: boolean, isMinter?: boolean | null, maxBalance: any, token: { __typename?: 'Token', id: string, name?: string | null, symbol?: string | null } }> | null, fixedRateExchanges?: Array<{ __typename?: 'FixedRateExchange', id: string, exchangeId: string, price: any, publishMarketSwapFee?: any | null, active: boolean, baseToken: { __typename?: 'Token', symbol?: string | null, name?: string | null, address: string, decimals: number }, datatoken: { __typename?: 'Token', symbol?: string | null, name?: string | null, address: string } }> | null } | null };

--- a/src/utils/subgraph/index.ts
+++ b/src/utils/subgraph/index.ts
@@ -1,12 +1,11 @@
 import { LoggerInstance } from '@oceanprotocol/lib'
-import { refocusExchange } from '@urql/exchange-refocus'
 import {
   Client,
+  OperationContext,
+  TypedDocumentNode,
   createClient,
   dedupExchange,
-  fetchExchange,
-  OperationContext,
-  TypedDocumentNode
+  fetchExchange
 } from 'urql'
 import { AccessDetails } from '../../@types/Compute'
 import { ITokenPriceQuery } from './TokenPriceQuery.gql.generated'
@@ -29,7 +28,7 @@ export function geturqlClient(subgraphUri) {
   if (!client)
     client = createClient({
       url: `${subgraphUri}/subgraphs/name/oceanprotocol/ocean-subgraph`,
-      exchanges: [dedupExchange, refocusExchange(), fetchExchange]
+      exchanges: [dedupExchange, fetchExchange]
     })
 
   return client


### PR DESCRIPTION
## Proposed Changes

  - Remove uneccessary dep: [@urql/exchange-refocus](https://www.npmjs.com/package/@urql/exchange-refocus)
> is an exchange for the [urql](https://github.com/urql-graphql/urql/blob/HEAD/README.md) GraphQL client that tracks currently active operations and redispatches them when the window regains focus

- fixes graphql codegeneration
